### PR TITLE
Added middleware annotation for assigning middleware to specific routes

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,3 +1,4 @@
+import { Middleware } from '@curveball/core';
 import Controller from './controller';
 
 export function method(httpMethod: string) {
@@ -9,6 +10,26 @@ export function method(httpMethod: string) {
 export function accept(mimeType: string) {
 
   return controllerDecorator('accept', mimeType);
+
+}
+
+/**
+ * This function returns a decorator which allows middleware to be applied to a specific controller route
+ */
+export function middleware(mw: Middleware) {
+
+  return (target: Controller, propertyKey: string) => {
+
+    if (!target.middleware) {
+      target.middleware = new Map();
+    }
+
+    if (!target.middleware.has(propertyKey)) {
+      target.middleware.set(propertyKey, []);
+    }
+    target.middleware.get(propertyKey)!.push(mw);
+
+  };
 
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { Middleware } from '@curveball/core';
+
 /**
  * A simple type to gather annotations on any method
  */
@@ -17,4 +19,7 @@ type MethodRoutes = {
 
   // If it's a string, it refers to a controller method, if it's null there is no default.
   default: string | null;
+
+  // Additional middleware specific to the route
+  middleware: Middleware[] | undefined;
 };

--- a/test/decorated-controller.ts
+++ b/test/decorated-controller.ts
@@ -2,6 +2,7 @@ import { Application } from '@curveball/core';
 import { expect } from 'chai';
 import FancyTestController from './fancy-test-controller';
 import BrokenTestController from './test-controller-broken';
+import MiddlewareController from './middleware-test-controller';
 
 describe('Controller Decorators', () => {
 
@@ -87,6 +88,20 @@ describe('Controller Decorators', () => {
       new BrokenTestController();
     }).to.throw(Error);
 
+  });
+  it('should apply middleware to routes when a middleware is specified as a decorator', async() => {
+
+    const app = new Application();
+    app.use(new MiddlewareController());
+    const response = await app.subRequest('GET', '/');
+    expect(response.status).to.equal(400);
+
+  });
+  it('should apply middleware to routes in order they are specified', async() => {
+    const app = new Application();
+    app.use(new MiddlewareController());
+    const response = await app.subRequest('POST', '/');
+    expect(response.body).to.equal('One Two Three');
   });
 
 });

--- a/test/middleware-test-controller.ts
+++ b/test/middleware-test-controller.ts
@@ -1,0 +1,35 @@
+import { Context } from '@curveball/core';
+import { BadRequest } from '@curveball/http-errors';
+import { Controller } from '../src';
+import { method, middleware } from '../src/decorators';
+
+async function badRequestMiddleware(ctx: Context) {
+  throw new BadRequest('This request was bad');
+}
+
+async function oneMiddleware(ctx: Context, next: () => Promise<void>) {
+  ctx.response.body = 'One';
+  await next();
+}
+
+async function twoMiddleware(ctx: Context, next: () => Promise<void>) {
+  ctx.response.body = ctx.response.body + ' Two';
+  await next();
+}
+
+export default class MiddlewareController extends Controller {
+
+  @method('GET')
+  @middleware(badRequestMiddleware)
+  get(ctx: Context) {
+    ctx.response.body = { foo: 'bar' };
+  }
+
+  @method('POST')
+  @middleware(oneMiddleware)
+  @middleware(twoMiddleware)
+  post(ctx: Context) {
+    ctx.response.body = ctx.response.body + ' Three';
+  }
+
+}


### PR DESCRIPTION
Hi. First of all, thanks for making Curveball, I really like this project and particularly enjoy the features for making easy use of HTTP standards.

I've been having a play around, and I was looking to assign a middleware to some, but not all routes in my app. The only way I've been able to do this so far is actually to not use the controller module and to wrap individual route middleware functions inside my group middleware on a route-by-route basis, like this:

```(typescript)
export const routes: Middleware[] = [
  router('/login').post(login),
  router('/').get(isAuthenticated(home)),
  router('/logout').post(isAuthenticated(logout))
]
```

I thought it might be nice if it was possible to create custom annotations for the controller methods to enable this kind of behaviour. I tried to make a PR for that but I couldn't work out how to do it without having a separate userland map for mapping the attribute name to the middleware, which seemed pretty fragile.

So instead I created a generic middleware annotation that allows you to add middleware to be invoked outside of the controller method. However, I still feel like there's probably a better way of doing this.

Is this a use case you would want to support? I thought I would submit the PR anyway, and if this isn't of any interest or there's a better way of doing it then by all means hit "reject"! Cheers